### PR TITLE
[FIX] Tests accessing same files

### DIFF
--- a/test/cli/estimate_options_test.cpp
+++ b/test/cli/estimate_options_test.cpp
@@ -5,9 +5,9 @@
 #include "ibf.h"
 #include "shared.h"
 
-std::filesystem::path tmp_dir = std::filesystem::temp_directory_path(); // get the temp directory
+struct estimate_options_test : public cli_test {};
 
-TEST_F(cli_test, no_options)
+TEST_F(estimate_options_test, no_options)
 {
     cli_test_result result = execute_app("needle estimate");
     std::string expected
@@ -21,7 +21,7 @@ TEST_F(cli_test, no_options)
     EXPECT_EQ(result.err, std::string{});
 }
 
-TEST_F(cli_test, fail_no_argument)
+TEST_F(estimate_options_test, fail_no_argument)
 {
     cli_test_result result = execute_app("needle estimate", "-m");
     std::string expected
@@ -34,63 +34,50 @@ TEST_F(cli_test, fail_no_argument)
     EXPECT_EQ(result.err, expected);
 }
 
-TEST_F(cli_test, with_argument)
+TEST_F(estimate_options_test, with_argument)
 {
     estimate_ibf_arguments ibf_args{};
     minimiser_arguments minimiser_args{};
     ibf_args.expression_levels = {1, 2};
     std::vector<double> fpr = {0.05};
-    std::vector<std::filesystem::path> sequence_files = {std::string(DATA_INPUT_DIR) + "exp_01.fasta"};
-    ibf_args.path_out = tmp_dir/"Test_";
+    std::vector<std::filesystem::path> sequence_files = {data("exp_01.fasta")};
+    ibf_args.path_out = "Test_";
     ibf(sequence_files, ibf_args, minimiser_args, fpr);
 
-    cli_test_result result = execute_app("needle estimate -i ", tmp_dir/"Test_", data("mini_gen.fasta"));
+    cli_test_result result = execute_app("needle estimate -i ", "Test_", data("mini_gen.fasta"));
     EXPECT_EQ(result.exit_code, 0);
     EXPECT_EQ(result.out, "");
     EXPECT_EQ(result.err, std::string{});
-
-    std::filesystem::remove(tmp_dir/"Test_IBF_Data");
-    std::filesystem::remove(tmp_dir/"Test_IBF_1");
-    std::filesystem::remove(tmp_dir/"Test_IBF_2");
-
 }
 
-TEST_F(cli_test, with_argument_normalization_method)
+TEST_F(estimate_options_test, with_argument_normalization_method)
 {
     estimate_ibf_arguments ibf_args{};
     minimiser_arguments minimiser_args{};
     ibf_args.expression_levels = {1, 2};
     std::vector<double> fpr = {0.05};
-    std::vector<std::filesystem::path> sequence_files = {std::string(DATA_INPUT_DIR) + "exp_01.fasta"};
-    ibf_args.path_out = tmp_dir/"Test_";
+    std::vector<std::filesystem::path> sequence_files = {data("exp_01.fasta")};
+    ibf_args.path_out = "Test_";
     ibf(sequence_files, ibf_args, minimiser_args, fpr);
 
-    cli_test_result result = execute_app("needle estimate -m -i ", tmp_dir/"Test_", data("mini_gen.fasta"));
+    cli_test_result result = execute_app("needle estimate -m -i ", "Test_", data("mini_gen.fasta"));
     EXPECT_EQ(result.exit_code, 0);
     EXPECT_EQ(result.out, "");
     EXPECT_EQ(result.err, std::string{});
-    std::filesystem::remove(tmp_dir/"Test_IBF_Data");
-    std::filesystem::remove(tmp_dir/"Test_IBF_1");
-    std::filesystem::remove(tmp_dir/"Test_IBF_2");
 }
 
-TEST_F(cli_test, with_argument_out)
+TEST_F(estimate_options_test, with_argument_out)
 {
     estimate_ibf_arguments ibf_args{};
     minimiser_arguments minimiser_args{};
     ibf_args.expression_levels = {1, 2};
     std::vector<double> fpr = {0.05};
-    std::vector<std::filesystem::path> sequence_files = {std::string(DATA_INPUT_DIR) + "exp_01.fasta"};
-    ibf_args.path_out = tmp_dir/"Test_";
+    std::vector<std::filesystem::path> sequence_files = {data("exp_01.fasta")};
+    ibf_args.path_out = "Test_";
     ibf(sequence_files, ibf_args, minimiser_args, fpr);
 
-    cli_test_result result = execute_app("needle estimate -o ", tmp_dir/"expressions.out","-i ", tmp_dir/"Test_", data("mini_gen.fasta"));
+    cli_test_result result = execute_app("needle estimate -o ", "expressions.out","-i ", "Test_", data("mini_gen.fasta"));
     EXPECT_EQ(result.exit_code, 0);
     EXPECT_EQ(result.out, "");
     EXPECT_EQ(result.err, std::string{});
-
-    std::filesystem::remove(tmp_dir/"Test_IBF_Data");
-    std::filesystem::remove(tmp_dir/"Test_IBF_1");
-    std::filesystem::remove(tmp_dir/"Test_IBF_2");
-    std::filesystem::remove(tmp_dir/"expressions.out");
 }

--- a/test/cli/ibf_options_test.cpp
+++ b/test/cli/ibf_options_test.cpp
@@ -2,7 +2,9 @@
 
 #include "cli_test.hpp"
 
-TEST_F(cli_test, ibf_no_options)
+struct ibf_options_test : public cli_test {};
+
+TEST_F(ibf_options_test, ibf_no_options)
 {
     cli_test_result result = execute_app("needle ibf");
     std::string expected
@@ -16,7 +18,7 @@ TEST_F(cli_test, ibf_no_options)
     EXPECT_EQ(result.err, std::string{});
 }
 
-TEST_F(cli_test, ibf_fail_no_argument)
+TEST_F(ibf_options_test, ibf_fail_no_argument)
 {
     cli_test_result result = execute_app("needle ibf", "-c");
     std::string expected
@@ -29,7 +31,7 @@ TEST_F(cli_test, ibf_fail_no_argument)
     EXPECT_EQ(result.err, expected);
 }
 
-TEST_F(cli_test, ibf_fail_contradiction)
+TEST_F(ibf_options_test, ibf_fail_contradiction)
 {
     cli_test_result result = execute_app("needle ibf -f 0.05 -e 1 -e 2 -l 1", data("exp_01.fasta"));
     std::string expected
@@ -41,7 +43,7 @@ TEST_F(cli_test, ibf_fail_contradiction)
     EXPECT_EQ(result.err, expected);
 }
 
-TEST_F(cli_test, ibf_fail_contradiction2)
+TEST_F(ibf_options_test, ibf_fail_contradiction2)
 {
     cli_test_result result = execute_app("needle ibf -f 0.05 -e 1 -e 2 --levels-by-genome ", data("exp_01.fasta"),
                                          data("exp_01.fasta"));
@@ -56,7 +58,7 @@ TEST_F(cli_test, ibf_fail_contradiction2)
     EXPECT_EQ(result.err, expected);
 }
 
-TEST_F(cli_test, ibf_with_argument)
+TEST_F(ibf_options_test, ibf_with_argument)
 {
     cli_test_result result = execute_app("needle ibf -f 0.05 -l 1", data("exp_01.fasta"));
     EXPECT_EQ(result.exit_code, 0);
@@ -64,7 +66,7 @@ TEST_F(cli_test, ibf_with_argument)
     EXPECT_EQ(result.err, std::string{});
 }
 
-TEST_F(cli_test, ibf_with_argument_with_options)
+TEST_F(ibf_options_test, ibf_with_argument_with_options)
 {
     cli_test_result result = execute_app("needle ibf -f 0.05 -k 4 -w 8 -l 1", data("exp_01.fasta"));
     EXPECT_EQ(result.exit_code, 0);
@@ -72,7 +74,7 @@ TEST_F(cli_test, ibf_with_argument_with_options)
     EXPECT_EQ(result.err, std::string{});
 }
 
-TEST_F(cli_test, ibfmin_no_options)
+TEST_F(ibf_options_test, ibfmin_no_options)
 {
     cli_test_result result = execute_app("needle ibfmin");
     std::string expected
@@ -86,7 +88,7 @@ TEST_F(cli_test, ibfmin_no_options)
     EXPECT_EQ(result.err, std::string{});
 }
 
-TEST_F(cli_test, ibfmin_fail_no_argument)
+TEST_F(ibf_options_test, ibfmin_fail_no_argument)
 {
     cli_test_result result = execute_app("needle ibfmin -c");
     std::string expected
@@ -99,7 +101,7 @@ TEST_F(cli_test, ibfmin_fail_no_argument)
     EXPECT_EQ(result.err, expected);
 }
 
-TEST_F(cli_test, ibfmin_fail_contradiction)
+TEST_F(ibf_options_test, ibfmin_fail_contradiction)
 {
     cli_test_result result = execute_app("needle ibfmin -f 0.05 -e 1 -e 2 -l 1", data("mini_example.minimiser"));
     std::string expected
@@ -111,7 +113,7 @@ TEST_F(cli_test, ibfmin_fail_contradiction)
     EXPECT_EQ(result.err, expected);
 }
 
-TEST_F(cli_test, ibfmin_fail_contradiction2)
+TEST_F(ibf_options_test, ibfmin_fail_contradiction2)
 {
     cli_test_result result = execute_app("needle ibfmin -f 0.05 -e 1 -e 2 --levels-by-genome ", data("exp_01.fasta"),
                                          data("mini_example.minimiser"));
@@ -126,7 +128,7 @@ TEST_F(cli_test, ibfmin_fail_contradiction2)
     EXPECT_EQ(result.err, expected);
 }
 
-TEST_F(cli_test, ibfmin_with_argument)
+TEST_F(ibf_options_test, ibfmin_with_argument)
 {
     cli_test_result result = execute_app("needle ibfmin -f 0.05 -l 1", data("mini_example.minimiser"));
     EXPECT_EQ(result.exit_code, 0);
@@ -134,7 +136,7 @@ TEST_F(cli_test, ibfmin_with_argument)
     EXPECT_EQ(result.err, std::string{});
 }
 
-TEST_F(cli_test, compressed)
+TEST_F(ibf_options_test, compressed)
 {
     cli_test_result result = execute_app("needle ibfmin -f 0.05 -l 1 -c ", data("mini_example.minimiser"));
     EXPECT_EQ(result.exit_code, 0);
@@ -142,7 +144,7 @@ TEST_F(cli_test, compressed)
     EXPECT_EQ(result.err, std::string{});
 }
 
-TEST_F(cli_test, more_hash_functions)
+TEST_F(ibf_options_test, more_hash_functions)
 {
     cli_test_result result = execute_app("needle ibfmin -f 0.05 -l 1 -n 4 ", data("mini_example.minimiser"));
     EXPECT_EQ(result.exit_code, 0);
@@ -150,7 +152,7 @@ TEST_F(cli_test, more_hash_functions)
     EXPECT_EQ(result.err, std::string{});
 }
 
-TEST_F(cli_test, expression_levels)
+TEST_F(ibf_options_test, expression_levels)
 {
     cli_test_result result = execute_app("needle ibfmin -f 0.05 -e 2 -e 4", data("mini_example.minimiser"));
     EXPECT_EQ(result.exit_code, 0);

--- a/test/cli/minimiser_options_test.cpp
+++ b/test/cli/minimiser_options_test.cpp
@@ -2,7 +2,9 @@
 
 #include "cli_test.hpp"
 
-TEST_F(cli_test, no_options)
+struct minimiser_options_test : public cli_test {};
+
+TEST_F(minimiser_options_test, no_options)
 {
     cli_test_result result = execute_app("needle minimiser");
     std::string expected
@@ -16,7 +18,7 @@ TEST_F(cli_test, no_options)
     EXPECT_EQ(result.err, std::string{});
 }
 
-TEST_F(cli_test, fail_no_argument)
+TEST_F(minimiser_options_test, fail_no_argument)
 {
     cli_test_result result = execute_app("needle minimiser", "--seed 0");
     std::string expected
@@ -29,7 +31,7 @@ TEST_F(cli_test, fail_no_argument)
     EXPECT_EQ(result.err, expected);
 }
 
-TEST_F(cli_test, with_arguments)
+TEST_F(minimiser_options_test, with_arguments)
 {
     cli_test_result result = execute_app("needle minimiser -k 4 -w 4 --seed 0", data("mini_example.fasta"));
     EXPECT_EQ(result.exit_code, 0);
@@ -37,7 +39,7 @@ TEST_F(cli_test, with_arguments)
     EXPECT_EQ(result.err, std::string{});
 }
 
-TEST_F(cli_test, cutoff)
+TEST_F(minimiser_options_test, cutoff)
 {
     cli_test_result result = execute_app("needle minimiser -k 4 -w 8 --cutoff 2", data("mini_example.fasta"));
     EXPECT_EQ(result.exit_code, 0);
@@ -45,7 +47,7 @@ TEST_F(cli_test, cutoff)
     EXPECT_EQ(result.err, std::string{});
 }
 
-TEST_F(cli_test, multiple_sample)
+TEST_F(minimiser_options_test, multiple_sample)
 {
     cli_test_result result = execute_app("needle minimiser -k 4 -w 8 --samples 2 ", data("mini_example.fasta"),
                                                                                    data("mini_example.fasta"));
@@ -54,7 +56,7 @@ TEST_F(cli_test, multiple_sample)
     EXPECT_EQ(result.err, std::string{});
 }
 
-TEST_F(cli_test, multithreads)
+TEST_F(minimiser_options_test, multithreads)
 {
     cli_test_result result = execute_app("needle minimiser -k 4 -w 8 -t 2", data("mini_example.fasta"),
                                                                             data("mini_example.fasta"));
@@ -63,7 +65,7 @@ TEST_F(cli_test, multithreads)
     EXPECT_EQ(result.err, std::string{});
 }
 
-TEST_F(cli_test, paired)
+TEST_F(minimiser_options_test, paired)
 {
     cli_test_result result = execute_app("needle minimiser -k 4 -w 8 -p ", data("mini_example.fasta"),
                                                                            data("mini_example.fasta"));

--- a/test/cli/needle_options_test.cpp
+++ b/test/cli/needle_options_test.cpp
@@ -2,7 +2,9 @@
 
 #include "cli_test.hpp"
 
-TEST_F(cli_test, no_options)
+struct needle_options_test : public cli_test {};
+
+TEST_F(needle_options_test, no_options)
 {
     cli_test_result result = execute_app("needle");
     std::string expected
@@ -16,7 +18,7 @@ TEST_F(cli_test, no_options)
     EXPECT_EQ(result.err, std::string{});
 }
 
-TEST_F(cli_test, fail_no_argument)
+TEST_F(needle_options_test, fail_no_argument)
 {
     cli_test_result result = execute_app("needle", "-v");
     std::string expected


### PR DESCRIPTION
Some API and CLI tests use the same (IBF) filepaths.
So, when `make -j3 test` is run, the API test might delete files that the CLI test still needs.

The CLI test do not need a temporary directory as a temporary working directory is created and deleted after the tests ran.

I gave each CLI test a unique test fixture that inherits from `cli_test`, otherwise one CLI test might delete the shared working directory while the other needs it. Making the fixtures unique to each translation unique will result in a unique working directory for each CLI test.
