### PR TITLE
[INFRA] Prepare option renaming

### DIFF
--- a/.github/workflows/ci_documentation.yml
+++ b/.github/workflows/ci_documentation.yml
@@ -52,7 +52,9 @@ jobs:
           mkdir build && cd build
           cmake .. -DCMAKE_BUILD_TYPE=Release \
                    -Dneedle_TEST=OFF \
-                   -Dneedle_DOCS=ON
+                   -Dneedle_DOCS=ON \
+                   -DNEEDLE_TEST=OFF \
+                   -DNEEDLE_DOCS=ON
 
       - name: Build docs
         working-directory: build


### PR DESCRIPTION
Since documentation runs on pull_request_target, this needs to be changed before actually changing the option.