### PR TITLE
[INFRA] Improve packaging

### DIFF
--- a/.github/workflows/ci_coverage.yml
+++ b/.github/workflows/ci_coverage.yml
@@ -60,7 +60,7 @@ jobs:
         working-directory: build
         run: |
           ccache -z
-          make -k tests
+          make -k
           ccache -svvx
 
       - name: Run tests

--- a/.github/workflows/ci_install.yml
+++ b/.github/workflows/ci_install.yml
@@ -82,7 +82,7 @@ jobs:
                                                  -DCPM_USE_LOCAL_PACKAGES=ON \
                                                  -DNEEDLE_TEST_BINARY_DIR=${GITHUB_WORKSPACE}/install/bin \
                                                  -DNEEDLE_TEST=ON
-          unshare -r -n make -k tests
+          unshare -r -n make -k
           test -n $(find . -type f -executable -name "needle") # needle binary should exist
           rm bin/needle
           test -z $(find . -type f -executable -name "needle") # needle binary should not exist

--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -58,7 +58,7 @@ jobs:
         working-directory: build
         run: |
           ccache -z
-          make -k tests
+          make -k
           ccache -svvx
 
       - name: Run tests

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -54,7 +54,7 @@ jobs:
         working-directory: build
         run: |
           ccache -z
-          make -k tests
+          make -k
           ccache -svvx
 
       - name: Run tests

--- a/.github/workflows/ci_sanitizer.yml
+++ b/.github/workflows/ci_sanitizer.yml
@@ -93,7 +93,7 @@ jobs:
 
       - name: Build tests
         working-directory: build
-        run: make -k tests
+        run: make -k
 
       - name: Run tests
         working-directory: build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,22 +27,10 @@ list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 # Specify the directories where to store the built archives, libraries and executables.
 include (output_directories)
 
-# An option to disable configuring and building the tests. Tests are enabled by default.
-# If your project-name (line 8 of this file) is `app-template`, the option will be `app-template_TEST`.
-# It can be used when calling CMake: `cmake .. -Dapp-template_TEST=OFF`.
-# It is good practice to allow disabling tests. If another project includes your application,
-# it might not want to build your tests.
-option (NEEDLE_TEST "Enable testing for NEEDLE." ON)
-option (NEEDLE_DOCS "Enable documentation for NEEDLE." OFF)
-option (NEEDLE_PACKAGE "Enable packaging for NEEDLE." OFF)
-
-if (NEEDLE_PACKAGE)
-    set (CPM_SOURCE_CACHE "${CMAKE_CURRENT_BINARY_DIR}/vendor")
-    set (CPM_USE_LOCAL_PACKAGES OFF)
-    include (package)
-elseif (EXISTS "${CMAKE_CURRENT_LIST_DIR}/vendor")
-    set (CPM_SOURCE_CACHE "${CMAKE_CURRENT_LIST_DIR}/vendor")
-endif ()
+# Options.
+option (NEEDLE_TEST "Enable testing for needle." ON)
+option (NEEDLE_DOCS "Enable documentation for needle." OFF)
+option (NEEDLE_PACKAGE "Enable packaging for needle." OFF)
 
 # Enable LTO if supported.
 include (CheckIPOSupported)
@@ -54,6 +42,14 @@ endif ()
 # Add packages.
 # We use CPM for package management: https://github.com/cpm-cmake/CPM.cmake
 # The added packages (e.g., hibf, sharg, seqan3) are defined in the `cmake/package-lock.cmake` file.
+if (NEEDLE_PACKAGE)
+    set (CPM_SOURCE_CACHE "${CMAKE_CURRENT_BINARY_DIR}/vendor")
+    set (CPM_USE_LOCAL_PACKAGES OFF)
+    include (package)
+elseif (EXISTS "${CMAKE_CURRENT_LIST_DIR}/vendor")
+    set (CPM_SOURCE_CACHE "${CMAKE_CURRENT_LIST_DIR}/vendor")
+endif ()
+
 include (CPM)
 CPMUsePackageLock (${CMAKE_CURRENT_LIST_DIR}/cmake/package-lock.cmake)
 
@@ -68,7 +64,7 @@ add_subdirectory (src)
 if (NEEDLE_TEST)
     list (APPEND CMAKE_CTEST_ARGUMENTS "--output-on-failure;--no-tests=error") # Must be before `enable_testing ()`.
     enable_testing ()
-    add_subdirectory (test EXCLUDE_FROM_ALL)
+    add_subdirectory (test)
 endif ()
 
 if (NEEDLE_DOCS)

--- a/cmake/cpack_install.cmake.in
+++ b/cmake/cpack_install.cmake.in
@@ -4,5 +4,5 @@
 
 # Only if creating the source package (`make package_source`).
 if (CPACK_SOURCE_INSTALLED_DIRECTORIES)
-    file (COPY "@CPM_SOURCE_CACHE@" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")
+    file (COPY "@CPM_SOURCE_CACHE@" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" PATTERN ".git" EXCLUDE)
 endif ()

--- a/cmake/package.cmake
+++ b/cmake/package.cmake
@@ -35,11 +35,6 @@ set (CPACK_PACKAGE_CHECKSUM "SHA256")
 set (CPACK_RESOURCE_FILE_LICENSE "${needle_SOURCE_DIR}/LICENSE.md")
 set (CPACK_RESOURCE_FILE_README "${needle_SOURCE_DIR}/README.md")
 
-# Already being called on source package, i.e. CPM is already downloaded.
-if (NOT CPM_DOWNLOAD_LOCATION)
-    set (CPM_DOWNLOAD_LOCATION "${needle_SOURCE_DIR}/cmake/CPM.cmake")
-endif ()
-
 configure_file ("${needle_SOURCE_DIR}/cmake/cpack_install.cmake.in" "${CMAKE_CURRENT_BINARY_DIR}/cpack_install.cmake"
                 @ONLY
 )

--- a/cmake/test/config.cmake
+++ b/cmake/test/config.cmake
@@ -56,7 +56,6 @@ endif ()
 
 # Add the check target that builds and runs tests.
 add_custom_target (check COMMAND ${CMAKE_CTEST_COMMAND} ${CMAKE_CTEST_ARGUMENTS})
-add_custom_target (tests)
 
 macro (add_app_test test_filename)
     file (RELATIVE_PATH source_file "${CMAKE_SOURCE_DIR}" "${CMAKE_CURRENT_LIST_DIR}/${test_filename}")
@@ -67,7 +66,6 @@ macro (add_app_test test_filename)
 
     add_dependencies (${target} ${PROJECT_NAME})
     add_dependencies (check ${target})
-    add_dependencies (tests ${target})
 
     add_test (NAME ${target} COMMAND ${target})
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,6 +14,6 @@ include (data/datasources.cmake)
 add_subdirectory (api)
 add_subdirectory (cli)
 
-message (STATUS "You can run `make tests` to build tests.")
+message (STATUS "You can run `make` to build tests.")
 message (STATUS "You can run `make test` to run tests.")
 message (STATUS "You can run `make check` to build and run tests.")


### PR DESCRIPTION
* Exclude `.git` when building source package
* Add tests to all target
* Remove `tests` target

## Dropped
Because the dependencies might also use CPM, we need to keep the source cache.
E.g., when not having cpm in the source cache, seqan3 would try to download it.
* Make CPM not call `find_package (Git REQUIRED)`
* Exclude `use_ccache, CPM` source when building source package 
* Put robin-hood in contrib
* Replace `{CPM,use_ccache}.cmake` with fetched scripts when building source package